### PR TITLE
Fixed STK PUSH bug. Replaced client side calls with a call to  a temporary custom API

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/packages/esm-billing-app/src/invoice/payments/initiate-payment/initiate-payment.component.tsx
+++ b/packages/esm-billing-app/src/invoice/payments/initiate-payment/initiate-payment.component.tsx
@@ -29,7 +29,7 @@ const InitiatePaymentDialog: React.FC<InitiatePaymentDialogProps> = ({ closeModa
   const { t } = useTranslation();
   const { mpesaCallbackUrl, passKey, shortCode, authorizationUrl, initiateUrl } = useConfig();
   const { mflCodeValue } = useSystemSetting('facility.mflcode');
-  const [notification, setNotification] = useState<string | null>(null);
+  const [notification, setNotification] = useState<{ type: 'error' | 'success'; message: string } | null>(null);
 
   const {
     control,
@@ -88,9 +88,9 @@ const InitiatePaymentDialog: React.FC<InitiatePaymentDialogProps> = ({ closeModa
           <h4>{t('paymentPayment', 'Bill Payment')}</h4>
           {notification && (
             <InlineNotification
-              kind="error"
+              kind={notification.type}
               title={t('mpesaError', 'Mpesa Error')}
-              subtitle={notification}
+              subtitle={notification.message}
               onCloseButtonClick={() => setNotification(null)}
             />
           )}

--- a/packages/esm-billing-app/src/m-pesa/mpesa-resource.tsx
+++ b/packages/esm-billing-app/src/m-pesa/mpesa-resource.tsx
@@ -1,39 +1,27 @@
-import { Buffer } from 'buffer';
-
-export const generateStkAccessToken = async (authorizationUrl: string, setNotification) => {
+export const initiateStkPush = async (
+  payload,
+  initiateUrl: string,
+  authorizationUrl: string,
+  setNotification: (notification: { type: 'error' | 'success'; message: string }) => void,
+) => {
   try {
-    const consumerKey = '';
-    const consumerSecret = '';
-    const auth = Buffer.from(`${consumerKey}:${consumerSecret}`).toString('base64');
-    const headers = {
-      'Content-Type': 'application/json',
-      Authorization: `Basic ${auth}`,
-    };
-    const response = await fetch(authorizationUrl, { method: 'GET', headers: headers });
-    const { access_token } = await response.json();
-    return access_token;
-  } catch (error) {
-    setNotification('Unable to reach the MPESA server, please try again later.');
-    throw error;
-  }
-};
+    // the backend URL for now we can use this one temporarily.
+    const url = 'https://compass-tau.vercel.app/api/mpesa/stk-push';
+    // const url = 'http://localhost:3000/api/mpesa/stk-push';
 
-export const initiateStkPush = async (payload, initiateUrl: string, authorizationUrl: string, setNotification) => {
-  try {
-    const access_token = await generateStkAccessToken(authorizationUrl, setNotification);
-    const headers = {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${access_token}`,
-    };
-    const response = await fetch(initiateUrl, {
+    const response = await fetch(url, {
       method: 'POST',
-      headers: headers,
-      body: JSON.stringify(payload),
+      body: JSON.stringify({
+        phoneNumber: payload.PhoneNumber,
+        amount: payload.Amount,
+        accountReference: payload.AccountReference,
+      }),
+      mode: `no-cors`,
     });
-
-    return await response.json();
+    setNotification({ message: 'Success', type: 'success' });
   } catch (err) {
-    setNotification('Unable to initiate Lipa Na Mpesa, please try again later.');
+    console.error(err);
+    setNotification({ message: 'Unable to initiate Lipa Na Mpesa, please try again later.', type: 'error' });
     throw err;
   }
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
I have changed the code a little bit. I have handled error and success responses on the UI. Also i have made a call to an external temporary API to handle the stk push to show what could be done when we have our own custom server. The code for how i setup that server is at this [link](https://github.com/amosmachora/compass/blob/master/app/api/mpesa/stk-push/route.ts).


I created a simple API route in NEXTJS and hosted it on vercel. However since sometimes daraja is quite slow it might still fail with a timeout error but i think its enough for the proof of concept.


## Screenshots

https://github.com/its-kios09/kenyaemr-esm-3.x/assets/81857018/205aac9e-2abe-443c-960a-a14306187842


<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
